### PR TITLE
Added @required to each parameter created in _addField.

### DIFF
--- a/example/lib/i18n.dart
+++ b/example/lib/i18n.dart
@@ -9,7 +9,7 @@ class I18n {
 
 String get subtitle => _getText("subtitle");
 
-String description({String var1, }) {
+String description({@required String var1, }) {
       String text = _getText("description");
               if (var1 != null) {
           text = text.replaceAll("%1\$s", var1);
@@ -17,7 +17,7 @@ String description({String var1, }) {
               return text;
       
       }
-      String littleTest({int age, }) {
+      String littleTest({@required int age, }) {
       String text = _getText("littleTest");
               if (age != null) {
           text = text.replaceAll("%age\$d", age.toString());

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.3"
+    version: "1.0.4"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/lib/flappy_translator.dart
+++ b/lib/flappy_translator.dart
@@ -180,7 +180,7 @@ class FlappyTranslator {
       final List<RegExpMatch> matches = regex.allMatches(defaultWord).toList();
       for (RegExpMatch match in matches) {
         final String parameterType = match.group(2) == "d" ? "int" : "String";
-        parameters += "$parameterType ${getParameterNameFromPlaceholder(match.group(0))}, ";
+        parameters += "@required $parameterType ${getParameterNameFromPlaceholder(match.group(0))}, ";
       }
 
       String result = """String $key({$parameters}) {


### PR DESCRIPTION
Presently a loca value of the form `A text with a variable : %1$s` will generate the following method

```
String description({String var1, }) {
  String text = _getText("description");
  if (var1 != null) {
    text = text.replaceAll("%1\$s", var1);
  }
  return text;    
}
```

which can be invoked as follows: `I18n.of(context).description()`, that is, without passing in a value for `var1`. 

However, it is clear that `var1` isn't an optional variable, thus the use of the annotation required is proposed.

As this is (somewhat) a breaking feature for existing users, another suggestion would be to define a setting as in #3, and add @required if necessary. Nevertheless, I believe that @required should be included by default.