### PR TITLE
Added setting to replace no break spaces with normal spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,20 @@ flappy_translator:
   start_index: 1
   depend_on_context: true
   use_single_quotes: false
+  replace_no_break_spaces: false
 ```
 
-| Setting           | Default | Description                                                                     |
-| ----------------- | ------- | ------------------------------------------------------------------------------- |
-| input_file_path   | N/A     | A path to the input CSV file.                                                   |
-| output_dir        | lib     | A directory to generate the output file.                                        |
-| file_name         | i18n    | A filename for the generated file.                                              |
-| class_name        | I18n    | A class name for the generated file.                                            |
-| delimiter         | ,       | A delimited to separate columns in the input CSV file.                          |
-| start_index       | 1       | The column index where translations begin (i.e. column index of main language.) |
-| depend_on_context | true    | Whether the generated localizations should depend on *BuildContext*             |
-| use_single_quotes | false   | Whether the generated file should use single or double quotes for strings.      |
+| Setting                 | Default | Description                                                                      |
+| ----------------------- | ------- | -------------------------------------------------------------------------------- |
+| input_file_path         | N/A     | A path to the input CSV file.                                                    |
+| output_dir              | lib     | A directory to generate the output file.                                         |
+| file_name               | i18n    | A filename for the generated file.                                               |
+| class_name              | I18n    | A class name for the generated file.                                             |
+| delimiter               | ,       | A delimited to separate columns in the input CSV file.                           |
+| start_index             | 1       | The column index where translations begin (i.e. column index of main language.)  |
+| depend_on_context       | true    | Whether the generated localizations should depend on *BuildContext*              |
+| use_single_quotes       | false   | Whether the generated file should use single or double quotes for strings.       |
+| replace_no_break_spaces | false   | Whether no break spaces (\u00A0) should be replaced with normal spaces (\u0020). |
 
 ### Run package
 

--- a/bin/flappy_translator.dart
+++ b/bin/flappy_translator.dart
@@ -21,6 +21,7 @@ class YamlArguments {
   static const startIndex = 'start_index';
   static const dependOnContext = 'depend_on_context';
   static const useSingleQuotes = 'use_single_quotes';
+  static const replaceNoBreakSpaces = 'replace_no_break_spaces';
 }
 
 void main(List<String> arguments) {
@@ -63,6 +64,7 @@ void main(List<String> arguments) {
     startIndex: settings[YamlArguments.startIndex],
     dependOnContext: settings[YamlArguments.dependOnContext],
     useSingleQuotes: settings[YamlArguments.useSingleQuotes],
+    replaceNoBreakSpaces: settings[YamlArguments.replaceNoBreakSpaces],
   );
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,6 +27,7 @@ flappy_translator:
   start_index: 1
   depend_on_context: true
   use_single_quotes: false
+  replace_no_break_spaces: false
 
 flutter:
   uses-material-design: true

--- a/lib/default_settings.dart
+++ b/lib/default_settings.dart
@@ -22,4 +22,7 @@ class DefaultSettings {
   /// The default value for whether the generated code should use single or double quotes for strings.
   /// Single is default for Dart but user may wish to use double to avoid needing to escape \' etc.
   static const useSingleQuotes = false;
+
+  /// The default value for whether the generated code should replace no break spaces (\u00A0) with normal spaces (\u0020)
+  static const replaceNoBreakSpaces = false;
 }


### PR DESCRIPTION
Due to https://github.com/smartnsoft/FlappyTranslator/issues/6 and having to deal with this issue in some Excel files too, I thought it would be good to add a setting so that these \u00A0 spaces could be replaced with normal spaces. This setting is defaulted to false.