### PR TITLE
Bugfix/validate parameter names

### DIFF
--- a/lib/src/services/flappy_translator.dart
+++ b/lib/src/services/flappy_translator.dart
@@ -322,6 +322,8 @@ class FlappyTranslator {
     var givenName = placeholder.substring(1, placeholder.length - 2);
     if (int.tryParse(givenName[0]) != null) {
       givenName = 'var$givenName';
+    } else if (RESERVED_WORDS.contains(givenName)) {
+      givenName = 'var$givenName';
     }
     return givenName;
   }


### PR DESCRIPTION
Resolves #35.

new => varnew

```csv
test,Here %new$d,,,
```

```dart
String test({
    @required int varnew,
  }) {
    String _text = _getText("test");
    if (varnew != null) {
      _text = _text.replaceAll("%new\$d", varnew.toString());
    }
    return _text;
  }
```