### PR TITLE
Feature/remove cla input output options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dev_dependencies:
   flappy_translator: 
 ```
 
-Note that *flappy_translator* requires dart sdk >= 2.7.
+Note that *flappy_translator* requires dart sdk >= 2.12.
 
 ### Define Settings
 
@@ -52,7 +52,7 @@ flappy_translator:
 
 | Setting                 | Default | Description                                                                        |
 | ----------------------- | ------- | ---------------------------------------------------------------------------------- |
-| input_file_path         | N/A     | A path to the input CSV/Excel file.                                                |
+| input_file_path         | N/A     | Required. A path to the input CSV/Excel file.                                                |
 | output_dir              | lib     | A directory to generate the output file.                                           |
 | file_name               | i18n    | A filename for the generated file.                                                 |
 | class_name              | I18n    | A class name for the generated file.                                               |
@@ -67,9 +67,7 @@ flappy_translator:
 
 ### Run package
 
-Make sure that your current working directory is the project root.
-
-An input file path must be supplied, either as a setting in *pubspec.yaml* or as a command line argument (CLA), while the output directory can also be optionally supplied as a CLA.
+Make sure that your current working directory is the project root. An input file path must be supplied as a setting in *pubspec.yaml*.
 
 ```sh
 flutter pub get

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Make sure that your current working directory is the project root. An input file
 
 ```sh
 flutter pub get
-flutter pub run flappy_translator <test.csv> <output dir>
+flutter pub run flappy_translator
 ```
 
 ### Update iOS Info.plist

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flappy_translator:
 
 | Setting                 | Default | Description                                                                        |
 | ----------------------- | ------- | ---------------------------------------------------------------------------------- |
-| input_file_path         | N/A     | Required. A path to the input CSV/Excel file.                                                |
+| input_file_path         | N/A     | Required. A path to the input CSV/Excel file.                                      |
 | output_dir              | lib     | A directory to generate the output file.                                           |
 | file_name               | i18n    | A filename for the generated file.                                                 |
 | class_name              | I18n    | A class name for the generated file.                                               |

--- a/bin/flappy_translator.dart
+++ b/bin/flappy_translator.dart
@@ -3,14 +3,49 @@ import 'dart:io';
 import 'package:flappy_translator/flappy_translator.dart';
 import 'package:yaml/yaml.dart';
 
+void main() {
+  String? inputFilePath;
+
+  // try to load settings from the project's pubspec.yaml
+  final settings = _loadSettings();
+  if (settings.isNotEmpty) {
+    if (settings.containsKey(_YamlArguments.inputFilePath)) {
+      inputFilePath = settings[_YamlArguments.inputFilePath];
+    }
+  }
+
+  // display an error and quit if the input file hasn't been specified
+  if ((inputFilePath == null)) {
+    print('[ERROR] Input file path not defined. This can be set as a command line argument or in pubspec.yaml\n');
+    return;
+  }
+
+  // parse csv to dart
+  final flappyTranslator = FlappyTranslator();
+  flappyTranslator.generate(
+    inputFilePath,
+    outputDir: settings[_YamlArguments.outputDir],
+    fileName: settings[_YamlArguments.fileName],
+    className: settings[_YamlArguments.className],
+    delimiter: settings[_YamlArguments.delimiter],
+    startIndex: settings[_YamlArguments.startIndex],
+    dependOnContext: settings[_YamlArguments.dependOnContext],
+    useSingleQuotes: settings[_YamlArguments.useSingleQuotes],
+    replaceNoBreakSpaces: settings[_YamlArguments.replaceNoBreakSpaces],
+    exposeGetString: settings[_YamlArguments.exposeGetString],
+    exposeLocaStrings: settings[_YamlArguments.exposeLocaStrings],
+    exposeLocaleMaps: settings[_YamlArguments.exposeLocaleMaps],
+  );
+}
+
 /// The path to the pubspec file path
-const pubspecFilePath = 'pubspec.yaml';
+const _pubspecFilePath = 'pubspec.yaml';
 
 /// The section id for flappy-translator in the yaml file
-const yamlSectionId = 'flappy_translator';
+const _yamlSectionId = 'flappy_translator';
 
 /// A class of arguments which the user can specify in pubspec.yaml
-class YamlArguments {
+class _YamlArguments {
   static const inputFilePath = 'input_file_path';
   static const outputDir = 'output_dir';
   static const className = 'class_name';
@@ -25,51 +60,16 @@ class YamlArguments {
   static const exposeLocaleMaps = 'expose_locale_maps';
 }
 
-void main() {
-  String? inputFilePath;
-
-  // try to load settings from the project's pubspec.yaml
-  final settings = loadSettings();
-  if (settings.isNotEmpty) {
-    if (settings.containsKey(YamlArguments.inputFilePath)) {
-      inputFilePath = settings[YamlArguments.inputFilePath];
-    }
-  }
-
-  // display an error and quit if the input file hasn't been specified
-  if ((inputFilePath == null)) {
-    print('[ERROR] Input file path not defined. This can be set as a command line argument or in pubspec.yaml\n');
-    return;
-  }
-
-  // parse csv to dart
-  final flappyTranslator = FlappyTranslator();
-  flappyTranslator.generate(
-    inputFilePath,
-    outputDir: settings[YamlArguments.outputDir],
-    fileName: settings[YamlArguments.fileName],
-    className: settings[YamlArguments.className],
-    delimiter: settings[YamlArguments.delimiter],
-    startIndex: settings[YamlArguments.startIndex],
-    dependOnContext: settings[YamlArguments.dependOnContext],
-    useSingleQuotes: settings[YamlArguments.useSingleQuotes],
-    replaceNoBreakSpaces: settings[YamlArguments.replaceNoBreakSpaces],
-    exposeGetString: settings[YamlArguments.exposeGetString],
-    exposeLocaStrings: settings[YamlArguments.exposeLocaStrings],
-    exposeLocaleMaps: settings[YamlArguments.exposeLocaleMaps],
-  );
-}
-
 /// Returns configuration settings for flappy_translator from pubspec.yaml
-Map<String?, dynamic> loadSettings() {
-  final file = File(pubspecFilePath);
+Map<String?, dynamic> _loadSettings() {
+  final file = File(_pubspecFilePath);
   final yamlString = file.readAsStringSync();
   final Map<dynamic, dynamic> yamlMap = loadYaml(yamlString);
 
   // determine <String?, dynamic> map from <dynamic, dynamic> yaml
   final settings = <String?, dynamic>{};
-  if (yamlMap.containsKey(yamlSectionId)) {
-    for (final kvp in yamlMap[yamlSectionId].entries) {
+  if (yamlMap.containsKey(_yamlSectionId)) {
+    for (final kvp in yamlMap[_yamlSectionId].entries) {
       settings[kvp.key] = kvp.value;
     }
   }

--- a/bin/flappy_translator.dart
+++ b/bin/flappy_translator.dart
@@ -25,8 +25,8 @@ class YamlArguments {
   static const exposeLocaleMaps = 'expose_locale_maps';
 }
 
-void main(List<String> arguments) {
-  String? inputFilePath, outputDir;
+void main() {
+  String? inputFilePath;
 
   // try to load settings from the project's pubspec.yaml
   final settings = loadSettings();
@@ -34,23 +34,11 @@ void main(List<String> arguments) {
     if (settings.containsKey(YamlArguments.inputFilePath)) {
       inputFilePath = settings[YamlArguments.inputFilePath];
     }
-    if (settings.containsKey(YamlArguments.outputDir)) {
-      outputDir = settings[YamlArguments.outputDir];
-    }
-  }
-
-  // parse command line arguments
-  if (arguments.isNotEmpty) {
-    inputFilePath = arguments.first;
-  }
-  if (arguments.length > 1) {
-    outputDir = arguments[1];
   }
 
   // display an error and quit if the input file hasn't been specified
   if ((inputFilePath == null)) {
-    print(
-        '[ERROR] Input file path not defined. This can be set as a command line argument or in pubspec.yaml\n');
+    print('[ERROR] Input file path not defined. This can be set as a command line argument or in pubspec.yaml\n');
     return;
   }
 
@@ -58,7 +46,7 @@ void main(List<String> arguments) {
   final flappyTranslator = FlappyTranslator();
   flappyTranslator.generate(
     inputFilePath,
-    outputDir: outputDir,
+    outputDir: settings[YamlArguments.outputDir],
     fileName: settings[YamlArguments.fileName],
     className: settings[YamlArguments.className],
     delimiter: settings[YamlArguments.delimiter],

--- a/bin/flappy_translator.dart
+++ b/bin/flappy_translator.dart
@@ -4,26 +4,19 @@ import 'package:flappy_translator/flappy_translator.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
-  String? inputFilePath;
-
   // try to load settings from the project's pubspec.yaml
   final settings = _loadSettings();
-  if (settings.isNotEmpty) {
-    if (settings.containsKey(_YamlArguments.inputFilePath)) {
-      inputFilePath = settings[_YamlArguments.inputFilePath];
-    }
-  }
 
   // display an error and quit if the input file hasn't been specified
-  if ((inputFilePath == null)) {
-    print('[ERROR] Input file path not defined. This can be set as a command line argument or in pubspec.yaml\n');
+  if ((settings[_YamlArguments.inputFilePath] == null)) {
+    print('[ERROR] Input file path not defined. This must be specified in pubspec.yaml\n');
     return;
   }
 
   // parse csv to dart
   final flappyTranslator = FlappyTranslator();
   flappyTranslator.generate(
-    inputFilePath,
+    settings[_YamlArguments.inputFilePath],
     outputDir: settings[_YamlArguments.outputDir],
     fileName: settings[_YamlArguments.fileName],
     className: settings[_YamlArguments.className],
@@ -66,8 +59,8 @@ Map<String?, dynamic> _loadSettings() {
   final yamlString = file.readAsStringSync();
   final Map<dynamic, dynamic> yamlMap = loadYaml(yamlString);
 
-  // determine <String?, dynamic> map from <dynamic, dynamic> yaml
-  final settings = <String?, dynamic>{};
+  // determine <String, dynamic> map from <dynamic, dynamic> yaml
+  final settings = <String, dynamic>{};
   if (yamlMap.containsKey(_yamlSectionId)) {
     for (final kvp in yamlMap[_yamlSectionId].entries) {
       settings[kvp.key] = kvp.value;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-nullsafety.0"
+    version: "2.0.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flappy_translator
 description: A tool which automatically generates Flutter localization resources from CSV and Excel files.
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 homepage: https://github.com/smartnsoft/FlappyTranslator
 repository: https://github.com/smartnsoft/FlappyTranslator
 issue_tracker: https://github.com/smartnsoft/FlappyTranslator/issues


### PR DESCRIPTION
Removes the ability to specify input filepath and output directory as cla arguments. Output filepath is already optional (defaults to lib), while input filepath must now be specified through pubspec.yaml.