### PR TITLE
Feature/default to key when default language not given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2.0.0-nullsafety.2] - 26/05/2021
 
 * Fixes an issue where certain analyzer warnings would be triggered in the generated code when using lint package.
+* Updates example.
 
 ## [2.0.0-nullsafety.1] - 10/04/2021
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tool which automatically generates Flutter localization resources from CSV and Excel files.
 
-This is especially useful as any team member can edit the CSV/Excel file, with the subsequent translations imported into the project with the use of a simple terminal command. This contrasts starkly to the default i18n approach in which dart files need to be manually for new keys and languages. More information can be found in [Internationalizing Flutter apps](https://flutter.dev/docs/development/accessibility-and-localization/internationalization#an-alternative-class-for-the-apps-localized-resources).
+This is especially useful as any team member can edit the CSV/Excel file, with the subsequent translations imported into the project via a terminal command. Basic variables (strings and integers) are supported, however neither genders nor plurals are planned to be supported. If you require such functionality, consider using [arb_generator](https://pub.dev/packages/arb_generator).
 
 Note that as of version 2.0.0, null safe code is generated. Please use version 1.5.0 for non-null safe projects.
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Locales are specified in the top row and are expected to be given in the form `e
 
 The column at `start_index` is considered the default language. This means that:
 
-1. This column must be completely filled, otherwise an error is printed to the console and code generation will not succeed.
+1. If this column does not have a value, the loca key instead will be used.
 2. If another language does not have translations for a given key, the value of the default language will be used.
 
 ### Keys

--- a/lib/src/services/code_generation/code_generator.dart
+++ b/lib/src/services/code_generation/code_generator.dart
@@ -104,9 +104,13 @@ class CodeGenerator {
     _fields += result;
 
     _maps[0][key] = defaultWord;
-    for (var wordIndex = 1; wordIndex < words.length; wordIndex++) {
+    for (var wordIndex = 1;
+        wordIndex < _supportedLanguages.length;
+        wordIndex++) {
       _maps[wordIndex][key] =
-          words[wordIndex].isEmpty ? defaultWord : words[wordIndex];
+          wordIndex < words.length && words[wordIndex].isNotEmpty
+              ? words[wordIndex]
+              : defaultWord;
     }
   }
 

--- a/lib/src/services/flappy_translator.dart
+++ b/lib/src/services/flappy_translator.dart
@@ -67,6 +67,7 @@ class FlappyTranslator {
     FlappyLogger.logProgress('Locales $supportedLanguages determined.');
 
     final localizationsTable = parser.localizationsTable;
+    Validator.validateLocalizationsTable(localizationsTable);
     FlappyLogger.logProgress('Parsing ${localizationsTable.length} key(s)...');
 
     for (final row in localizationsTable) {

--- a/lib/src/services/parsing/file_parser.dart
+++ b/lib/src/services/parsing/file_parser.dart
@@ -57,7 +57,11 @@ abstract class FileParser {
         .map(
           (row) => LocalizationTableRow(
             key: row.first,
-            defaultWord: row.sublist(startIndex).first,
+            // if there is not a default word, use key
+            defaultWord: row.sublist(startIndex).isNotEmpty &&
+                    row.sublist(startIndex).first.isNotEmpty
+                ? row.sublist(startIndex).first
+                : row.first,
             words: row.sublist(startIndex),
             raw: row,
           ),

--- a/lib/src/services/validation/validator.dart
+++ b/lib/src/services/validation/validator.dart
@@ -10,7 +10,7 @@ import '../../utils/flappy_logger.dart';
 abstract class Validator {
   /// Validates whether [file] is valid
   ///
-  /// If any error occurs, process is derminated
+  /// If any error occurs, process is terminated
   static void validateFile(File file) {
     // check that the file exists
     if (!file.existsSync()) {
@@ -27,7 +27,7 @@ abstract class Validator {
 
   /// Validates whether [supportedLanguages] are valid
   ///
-  /// If any error occurs, process is derminated
+  /// If any error occurs, process is terminated
   static void validateSupportedLanguages(List<String> supportedLanguages) {
     for (final supportedLanguage in supportedLanguages) {
       if (!supportedLanguage.isValidLocale) {
@@ -45,9 +45,19 @@ abstract class Validator {
     }
   }
 
+  /// Validates whether [localizationsTable] is valid
+  ///
+  /// If any error occurs, process is terminated
+  static void validateLocalizationsTable(
+      List<LocalizationTableRow> localizationsTable) {
+    if (localizationsTable.isEmpty) {
+      FlappyLogger.logError('No keys found.');
+    }
+  }
+
   /// Validates whether [row] is valid
   ///
-  /// If any error occurs, process is derminated
+  /// If any error occurs, process is terminated
   static void validateLocalizationTableRow(
     LocalizationTableRow row, {
     required int numberSupportedLanguages,

--- a/test/services/validation/validator_test.dart
+++ b/test/services/validation/validator_test.dart
@@ -32,11 +32,21 @@ void main() {
     });
   });
 
+  group('validateLocalizationsTable', () {
+    test('localization table is empty', () {
+      Validator.validateLocalizationsTable([]);
+    });
+  });
+
   group('validateLocalizationTableRow', () {
     test('key is reserved word', () {
       Validator.validateLocalizationTableRow(
         LocalizationTableRow(
-            key: 'for', defaultWord: 'a', words: ['a'], raw: ['for', 'a']),
+          key: 'for',
+          defaultWord: 'a',
+          words: ['a'],
+          raw: ['for', 'a'],
+        ),
         numberSupportedLanguages: 1,
       );
     });
@@ -44,7 +54,11 @@ void main() {
     test('key is type', () {
       Validator.validateLocalizationTableRow(
         LocalizationTableRow(
-            key: 'int', defaultWord: 'a', words: ['a'], raw: ['int', 'a']),
+          key: 'int',
+          defaultWord: 'a',
+          words: ['a'],
+          raw: ['int', 'a'],
+        ),
         numberSupportedLanguages: 1,
       );
     });
@@ -52,7 +66,11 @@ void main() {
     test('key is not valid variable name', () {
       Validator.validateLocalizationTableRow(
         LocalizationTableRow(
-            key: 'MyKey', defaultWord: 'a', words: ['a'], raw: ['MyKey', 'a']),
+          key: 'MyKey',
+          defaultWord: 'a',
+          words: ['a'],
+          raw: ['MyKey', 'a'],
+        ),
         numberSupportedLanguages: 1,
       );
     });


### PR DESCRIPTION
When no value (or empty) is given for default language, then use key as localization. Previously this would have triggered an error and stopped the code generation.