### PR TITLE
Add ignore for non_constant_identifier_names lint

### DIFF
--- a/lib/src/services/code_generation/code_generator.dart
+++ b/lib/src/services/code_generation/code_generator.dart
@@ -32,7 +32,7 @@ class CodeGenerator {
     bool exposeLocaleMaps = DefaultSettings.exposeLocaleMaps,
   }) : _quoteString = useSingleQuotes ? '\'' : '"' {
     // construct template
-    _template = Template.begining +
+    _template = Template.beginning +
         (dependOnContext
             ? Template.middleDependContext
             : Template.middleDontDependContext) +

--- a/lib/src/services/code_generation/template.dart
+++ b/lib/src/services/code_generation/template.dart
@@ -1,7 +1,7 @@
 abstract class Template {
   static const begining = '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: public_member_api_docs, prefer_single_quotes, avoid_escaping_inner_quotes, prefer_const_constructors, sort_constructors_first, always_specify_types
+// ignore_for_file: public_member_api_docs, prefer_single_quotes, avoid_escaping_inner_quotes, prefer_const_constructors, sort_constructors_first, always_specify_types, non_constant_identifier_names
 
 import 'dart:async';
 

--- a/lib/src/services/code_generation/template.dart
+++ b/lib/src/services/code_generation/template.dart
@@ -1,5 +1,5 @@
 abstract class Template {
-  static const begining = '''
+  static const beginning = '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: public_member_api_docs, prefer_single_quotes, avoid_escaping_inner_quotes, prefer_const_constructors, sort_constructors_first, always_specify_types, non_constant_identifier_names
 

--- a/test/services/code_generation/code_generator_test.dart
+++ b/test/services/code_generation/code_generator_test.dart
@@ -222,7 +222,7 @@ class I18nDelegate extends LocalizationsDelegate<I18n> {
   });
 
   test(
-      'When a variable name begining with a number is given, expect var is prepended',
+      'When a variable name beginning with a number is given, expect var is prepended',
       () {
     final codeGenerator = CodeGenerator(
       className: 'I18n',


### PR DESCRIPTION
Adds ignore clause for non_constant_identifier_names lint warning.
Also fixes small typo in code.