### PR TITLE
Skip Empty Lines in CSV Parsing

### DIFF
--- a/lib/src/services/parsing/csv_parser.dart
+++ b/lib/src/services/parsing/csv_parser.dart
@@ -21,6 +21,9 @@ class CSVParser extends FileParser {
   void parseFile() {
     final lines = file.readAsLinesSync();
     for (final line in lines) {
+      if (line.trim().isEmpty) {
+        continue;
+      }
       final lineElements = _csvConverter
           .convert(line, fieldDelimiter: fieldDelimiter)
           .first


### PR DESCRIPTION
The current implementation of CSVParser processes all lines in the CSV file, including empty lines. This can lead to unnecessary entries in the parsed contents. We need to update the parseFile method to skip any empty lines, ensuring that only lines with actual data are processed. This improvement will enhance the efficiency and accuracy of the CSV parsing process.